### PR TITLE
bug : lint 오류 수정

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,4 @@
-vite.config.ts;
+dist/
+assets/
+*.config.js
+*.config.ts

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "import/prefer-default-export": "off",
     "react/require-default-props": "off",
     "react/button-has-type": "warn",
-    "react/jsx-props-no-spreading": "off"
+    "react/jsx-props-no-spreading": "off",
+    "no-underscore-dangle": ["error", { "allow": ["_default"] }]
   }
 }


### PR DESCRIPTION
1. dist파일 ESLint 검사 예외
2. 특정 변수명은 허용하고, 나머지 밑줄 사용은 여전히 금지하는 코드 추가


` "no-underscore-dangle": ["error", { "allow": ["_default"] }] ` 




```
const _default = "allowed"; // 허용됨
const _anotherVariable = "not allowed"; // 에러 발생
```